### PR TITLE
Add OCR dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ streamlit
 PyPDF2
 pandas
 requests
+PyMuPDF
+pytesseract


### PR DESCRIPTION
## Summary
- add PyMuPDF and pytesseract dependencies in `requirements.txt`

## Testing
- `od -c requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684a0306b1b88328b1566bdb12dee8bd