### PR TITLE
Update README requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,12 @@ This Streamlit app processes SAT questions from a PDF file using the Claude API 
 - Python 3.7+
 - Streamlit
 - PyPDF2
+- PyMuPDF
 - pandas
+- pytesseract
 - requests
+
+`pytesseract` requires the Tesseract OCR engine to be installed on your system.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- document PyMuPDF and pytesseract in requirements
- note that Tesseract OCR is needed for pytesseract

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a05d78c548328a18215a86ebcc895