### PR TITLE
Add Streamlit interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The script uses the Mathpix API to perform OCR on each page and OpenAI models to
 - requests
 - PyMuPDF
 - Pillow
-
+- streamlit
 ## Installation
 
 1. Clone this repository and install dependencies:
@@ -37,6 +37,15 @@ python parse_sat_pdf.py path/to/questions.pdf --csv parsed_questions.csv
 ```
 
 Images extracted from the PDF will be stored in the `images/` directory and the questions will be appended to the CSV file.
+
+## Streamlit Interface
+
+Launch an interactive UI:
+```bash
+streamlit run streamlit_app.py
+```
+Upload a PDF, click "Convert" and then use the provided download button to save the resulting CSV.
+
 
 ## Output Format
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ pandas
 requests
 PyMuPDF
 Pillow
+
+streamlit

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,29 @@
+import os
+import tempfile
+import streamlit as st
+import parse_sat_pdf
+
+st.title("PDF to CSV Converter")
+
+uploaded_file = st.file_uploader("Drag and drop a PDF", type="pdf")
+
+if uploaded_file is not None:
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmp:
+        tmp.write(uploaded_file.getvalue())
+        tmp_path = tmp.name
+
+    output_csv = os.path.join(tempfile.gettempdir(), "converted_questions.csv")
+    parse_sat_pdf.CSV_PATH = output_csv
+
+    if st.button("Convert"):
+        with st.spinner("Processing PDF..."):
+            parse_sat_pdf.process_pdf(tmp_path)
+        with open(output_csv, "rb") as f:
+            st.download_button(
+                label="Download CSV",
+                data=f,
+                file_name="questions.csv",
+                mime="text/csv",
+            )
+        os.remove(output_csv)
+        os.remove(tmp_path)


### PR DESCRIPTION
## Summary
- add simple Streamlit UI to convert uploaded PDFs to CSV
- include Streamlit in dependencies
- document new interface in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile streamlit_app.py`
- `python -m py_compile parse_sat_pdf.py`


------
https://chatgpt.com/codex/tasks/task_e_685623a63ecc8328800b569b46efd51f