### PR TITLE
Improve Mathpix error logging

### DIFF
--- a/parse_sat_pdf.py
+++ b/parse_sat_pdf.py
@@ -68,8 +68,8 @@ def extract_mathpix_data(image_bytes: bytes, retries: int = 3) -> Dict[str, Any]
             )
             if resp.status_code == 200:
                 return resp.json()
-        except Exception:
-            pass
+        except Exception as e:
+            logging.error(f"Mathpix attempt {attempt + 1} failed: {e}")
         time.sleep(2 ** attempt)
     raise RuntimeError(f"Mathpix request failed after {retries} attempts")
 


### PR DESCRIPTION
## Summary
- log Mathpix errors so problems are visible and include the attempt number

## Testing
- `python -m py_compile parse_sat_pdf.py`

------
https://chatgpt.com/codex/tasks/task_e_6856e5dc823c83289c633af4723d014b