### PR TITLE
Refactor page parsing

### DIFF
--- a/parse_sat_pdf.py
+++ b/parse_sat_pdf.py
@@ -30,15 +30,11 @@ os.makedirs(IMAGE_DIR, exist_ok=True)
 openai_client = openai.OpenAI(api_key=OPENAI_API_KEY)
 
 
-def parse_pdf_page(pdf_path: str, page_num: int) -> bytes:
-    """Render a PDF page to image bytes."""
-    doc = fitz.open(pdf_path)
-    try:
-        page = doc[page_num]
-        pix = page.get_pixmap(dpi=300)
-        return pix.tobytes("png")
-    finally:
-        doc.close()
+def parse_pdf_page(doc: fitz.Document, page_num: int) -> bytes:
+    """Render a page from an open ``fitz.Document`` to PNG bytes."""
+    page = doc[page_num]
+    pix = page.get_pixmap(dpi=300)
+    return pix.tobytes("png")
 
 
 def extract_mathpix_data(image_bytes: bytes, retries: int = 3) -> Dict[str, Any]:
@@ -134,26 +130,28 @@ def append_to_csv(questions: List[Dict[str, Any]], csv_path: str = CSV_PATH) -> 
 
 def process_pdf(pdf_path: str) -> None:
     doc = fitz.open(pdf_path)
-    for page_num in range(len(doc)):
-        print(f"Processing page {page_num + 1}/{len(doc)}")
-        page_bytes = parse_pdf_page(pdf_path, page_num)
-        mathpix_data = extract_mathpix_data(page_bytes)
-        text = mathpix_data.get("text", "")
-        logging.info(f"Mathpix OCR text snippet: {text[:200]}")
-        images = mathpix_data.get("images", []) or []
+    try:
+        for page_num in range(len(doc)):
+            print(f"Processing page {page_num + 1}/{len(doc)}")
+            page_bytes = parse_pdf_page(doc, page_num)
+            mathpix_data = extract_mathpix_data(page_bytes)
+            text = mathpix_data.get("text", "")
+            logging.info(f"Mathpix OCR text snippet: {text[:200]}")
+            images = mathpix_data.get("images", []) or []
 
-        image_map = {}
-        for idx, img in enumerate(images, start=1):
-            question_id = str(uuid.uuid4())[:8]
-            path = save_image(img.get("data", ""), question_id, f"img{idx}")
-            image_map[f"image{idx}"] = path
+            image_map = {}
+            for idx, img in enumerate(images, start=1):
+                question_id = str(uuid.uuid4())[:8]
+                path = save_image(img.get("data", ""), question_id, f"img{idx}")
+                image_map[f"image{idx}"] = path
 
-        questions = structure_question_with_openai(text, image_map)
-        for q in questions:
-            if q.get("image_path") in image_map:
-                q["image_path"] = image_map[q["image_path"]]
-        append_to_csv(questions)
-    doc.close()
+            questions = structure_question_with_openai(text, image_map)
+            for q in questions:
+                if q.get("image_path") in image_map:
+                    q["image_path"] = image_map[q["image_path"]]
+            append_to_csv(questions)
+    finally:
+        doc.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- reuse an opened PDF document when rendering pages
- support open fitz.Document in `parse_pdf_page`

## Testing
- `python -m py_compile parse_sat_pdf.py`


------
https://chatgpt.com/codex/tasks/task_e_6856e5d745f08328a9ccb65f98fa2e9f