### PR TITLE
Fix parse_pdf_page signature

### DIFF
--- a/parse_sat_pdf.py
+++ b/parse_sat_pdf.py
@@ -51,15 +51,11 @@ def clean_json_reply(reply: str) -> str:
     return cleaned.strip()
 
 
-def parse_pdf_page(pdf_path: str, page_num: int) -> bytes:
-    """Render a PDF page to image bytes."""
-    doc = fitz.open(pdf_path)
-    try:
-        page = doc[page_num]
-        pix = page.get_pixmap(dpi=300)
-        return pix.tobytes("png")
-    finally:
-        doc.close()
+def parse_pdf_page(doc: fitz.Document, page_num: int) -> bytes:
+    """Render a page from an open PDF document to image bytes."""
+    page = doc[page_num]
+    pix = page.get_pixmap(dpi=300)
+    return pix.tobytes("png")
 
 
 


### PR DESCRIPTION
## Summary
- refactor `parse_pdf_page` to accept an open `fitz.Document`
- render pages directly from the provided document

## Testing
- `python -m py_compile parse_sat_pdf.py`


------
https://chatgpt.com/codex/tasks/task_e_6856eee6bf3483289446db524486bf25