### PR TITLE
Add csv path argument support

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -13,11 +13,10 @@ if uploaded_file is not None:
         tmp_path = tmp.name
 
     output_csv = os.path.join(tempfile.gettempdir(), "converted_questions.csv")
-    parse_sat_pdf.CSV_PATH = output_csv
 
     if st.button("Convert"):
         with st.spinner("Processing PDF..."):
-            parse_sat_pdf.process_pdf(tmp_path)
+            parse_sat_pdf.process_pdf(tmp_path, output_csv)
         with open(output_csv, "rb") as f:
             st.download_button(
                 label="Download CSV",


### PR DESCRIPTION
## Summary
- allow `append_to_csv` to optionally take a custom CSV path
- plumb csv path through `process_pdf`
- update command-line usage to pass csv argument directly
- adjust Streamlit app to call `process_pdf` with a CSV path

## Testing
- `python -m py_compile parse_sat_pdf.py streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_6856eee6e6c88328bfc8e8168d3e2a62