### PR TITLE
Handle stray backslashes in OpenAI JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ python parse_sat_pdf.py path/to/questions.pdf --csv parsed_questions.csv
 
 Images extracted from the PDF will be stored in the `images/` directory and the questions will be appended to the CSV file.
 
+If the OpenAI response contains stray backslashes that break JSON formatting,
+the parser will attempt to escape them and retry parsing automatically.
+
 ## Streamlit Interface
 
 Launch an interactive UI:


### PR DESCRIPTION
## Summary
- add `safe_json_loads` helper for more robust JSON parsing
- use it in `structure_question_with_openai`
- document escaping behavior in README

## Testing
- `python -m py_compile parse_sat_pdf.py streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_6856f2d212b483289e7e58064f9a8145