### PR TITLE
Fix stray backslash in prompt

### DIFF
--- a/parse_sat_pdf.py
+++ b/parse_sat_pdf.py
@@ -113,7 +113,7 @@ def structure_question_with_openai(text: str, image_map: Dict[str, str], retries
         "choice_D, correct_answer, domain, skill, difficulty, image_path. "
         "Use the provided image names when the text references graphs or tables. "
         "If domain, skill, or difficulty are missing, use 'Not specified'. "
-        "Do not fabricate information."\
+        "Do not fabricate information."
     )
     content = f"OCR TEXT:\n{text}\nIMAGE MAP:{json.dumps(image_map)}"
     messages = [


### PR DESCRIPTION
## Summary
- remove leftover backslash at end of prompt

## Testing
- `python -m py_compile parse_sat_pdf.py`


------
https://chatgpt.com/codex/tasks/task_e_6856f2d38330832883507069079895d3