### PR TITLE
Improve JSON parsing and CSV handling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,6 @@ requests
 PyMuPDF
 Pillow
 
+json5
+
 streamlit


### PR DESCRIPTION
## Summary
- add `json5` parsing fallback for openai replies
- request JSON object format from OpenAI
- catch errors when reading existing CSV
- document new dependency

## Testing
- `python -m py_compile parse_sat_pdf.py streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_6856f892bb1883289bfd6fe40ac294d4