### PR TITLE
Handle free response questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ The CSV contains the following columns:
 - `difficulty`
 - `image_path`
 
+If a question has no answer choices, the `choice_A` through `choice_D` fields
+will contain the text `free response` so you can easily identify these
+questions when reviewing the CSV.
+
 ## License
 
 This project is licensed under the MIT License.

--- a/parse_sat_pdf.py
+++ b/parse_sat_pdf.py
@@ -156,7 +156,9 @@ def structure_question_with_openai(text: str, image_map: Dict[str, str], retries
         "Use the identifier following 'Question ID' for question_id. Do not fabricate information. "
         "If the text references diagrams, graphs, tables, or other images, set image_path to 'needs image'. "
         "If any answer choice is an image, its value should be 'needs image'. "
-        "If domain, skill, or difficulty are missing, use 'Not specified'."
+        "If domain, skill, or difficulty are missing, use 'Not specified'. "
+        "If a question has no answer choices, mark it as a free response question "
+        "and set choice_A, choice_B, choice_C, and choice_D to 'free response'."
     )
     content = f"OCR TEXT:\n{text}\nIMAGE MAP:{json.dumps(image_map)}"
     messages = [


### PR DESCRIPTION
## Summary
- mention `free response` rule in README
- advise OpenAI prompt to set answer choices to `free response` for free response questions

## Testing
- `python -m py_compile parse_sat_pdf.py streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_6861b3ab5c848328b3a66ee7edfb5261